### PR TITLE
FIX - exp() and besseli() max out to inf if kappa becomes large

### DIFF
--- a/@VonMisesMixture/computeLikelihood.m
+++ b/@VonMisesMixture/computeLikelihood.m
@@ -70,6 +70,9 @@ for idx = 1 : nMixtures
     exp(p.Results.Kappa(idx) .* cos(p.Results.Angles - p.Results.Mu(idx)));
 end
 
+% Fix to accommodate for too large Kappa values
+compLik(~isfinite(compLik)) = 0;
+
 % Accumulate component likelihoods to get the total likelihood.
 likelihood = compLik * p.Results.CProp(:);
 

--- a/@VonMisesMixture/computeLikelihood.m
+++ b/@VonMisesMixture/computeLikelihood.m
@@ -70,8 +70,9 @@ for idx = 1 : nMixtures
     exp(p.Results.Kappa(idx) .* cos(p.Results.Angles - p.Results.Mu(idx)));
 end
 
-% Fix to accommodate for too large Kappa values
-compLik(~isfinite(compLik)) = 0;
+% Fix to accommodate for too large Kappa values, causing inf/inf to go to
+% NaN
+compLik(~isfinite(compLik)) = 10.560077263485184; % empirically determined limit of (double) exp(K)./(2.*pi.*besseli(0,K));
 
 % Accumulate component likelihoods to get the total likelihood.
 likelihood = compLik * p.Results.CProp(:);


### PR DESCRIPTION
This fix addresses the case when the computation of the likelihood results in non-finite values, due the exp() and besseli() maxing out.